### PR TITLE
Let the user handle their own logging. Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,10 +53,8 @@ module.exports = function soapRequest(opts = {
       });
     }).catch((error) => {
       if (error.response) {
-        console.error(`SOAP FAIL: ${error}`);
         reject(error.response.data);
       } else {
-        console.error(`SOAP FAIL: ${error}`);
         reject(error);
       }
     });


### PR DESCRIPTION
If you're going to reject anyway, why would you do a "console.error" before that.
Let the user handle their own logging.

I want to only log errors in some cases and I cannot get over that without editing the library...